### PR TITLE
Update stock.py

### DIFF
--- a/stock.py
+++ b/stock.py
@@ -11,6 +11,10 @@ ticker_symbol = st.text_input("stock", "AAPL")
 start_date = st.date_input("choose start data", pd.to_datetime('2024-01-01'))
 end_date = st.date_input("choose end data", pd.to_datetime('today'))
 
+changepoint_prior_scale = st.slider("Changepoint Prior Scale (default 0.05)", 0.001, 0.5, 0.05)
+seasonality_mode = st.selectbox("Seasonality Mode", ["additive", "multiplicative"])
+seasonality_prior_scale = st.slider("Seasonality Prior Scale (default 10.0)", 1.0, 50.0, 10.0)
+
 if st.button('get data'):
     ticker_data = yf.Ticker(ticker_symbol)
     ticker_df = ticker_data.history(period='1d', start=start_date, end=end_date)
@@ -32,7 +36,11 @@ if st.button('get data'):
         df_prophet.columns = ['ds', 'y']  
         df_prophet['ds'] = pd.to_datetime(df_prophet['ds']).dt.tz_localize(None)  
 
-        model = Prophet()
+        model = Prophet(
+            changepoint_prior_scale=changepoint_prior_scale,
+            seasonality_mode=seasonality_mode,
+            seasonality_prior_scale=seasonality_prior_scale
+        )
         model.fit(df_prophet)
 
         future = model.make_future_dataframe(periods=365)


### PR DESCRIPTION
Add function allows users to adjust key parameters of the Prophet model to explore impact on stock price predictions:

1.changepoint_prior_scale: Controls how sensitive the model is to changes in trend. A higher value captures more frequent trend shifts, while a lower value results in smoother trends.

2.seasonality_mode: Determines whether the seasonal effect is additive or multiplicative. Use multiplicative when seasonal effects scale with the data, which is often the case in financial markets.

3.seasonality_prior_scale: Controls the flexibility of the seasonal component. Larger values capture more seasonal variation, while smaller values smooth the seasonality.

![image](https://github.com/user-attachments/assets/a148654a-52ce-45ec-86b6-6cf1bd19975e)

